### PR TITLE
Fix `files` configuration key error

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func run(c *cli.Context) error {
 		},
 		Config: Config{
 			APIKey:     c.String("api-key"),
-			Files:      c.StringSlice("api-key"),
+			Files:      c.StringSlice("files"),
 			FileExists: c.String("file-exists"),
 			Checksum:   c.StringSlice("checksum"),
 			Draft:      c.Bool("draft"),


### PR DESCRIPTION
Currently the `files` option doesn't have any effect (i.e. no asset is published on GitHub).

This patch fixes the corresponding typo in `main.go`.

Closes: #16