### PR TITLE
Fix extraction of tag from commit ref to handle `/` char

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -116,7 +116,7 @@ func (p Plugin) Exec() error {
 		Client:     client,
 		Owner:      p.Repo.Owner,
 		Repo:       p.Repo.Name,
-		Tag:        filepath.Base(p.Commit.Ref),
+		Tag:        strings.TrimPrefix(p.Commit.Ref, "refs/tags/"),
 		Draft:      p.Config.Draft,
 		Prerelease: p.Config.Prerelease,
 		FileExists: p.Config.FileExists,


### PR DESCRIPTION
Previously, tags with a `/` character were not correctly handled because
`filepath.Base` was used to extract the tag name from the commit ref. This would only return the last element of path, so a tag like `test/v1.2.3` would end up as `v1.2.3`.

This change allows for tags like `test/v1.2.3` to work properly by
trimming the `refs/tags/` prefix from the commit ref.

Issue #24