### PR TITLE
Don't try to read as file name for strings len() > 255

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -162,6 +162,9 @@ func (p Plugin) Exec() error {
 }
 
 func readStringOrFile(input string) (string, error) {
+	if len(input) > 255 {
+		return input, nil
+	}
 	// Check if input is a file path
 	if _, err := os.Stat(input); err != nil && os.IsNotExist(err) {
 		// No file found => use input as result

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,31 @@
+package main // Needs to be same package to be able to access the private func "readStringOrFile"
+
+import (
+	"testing"
+)
+
+func TestReadStringOrFileSelf(t *testing.T) {
+	contents, err := readStringOrFile("./plugin_test.go")
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(contents) == 0 {
+		t.Errorf("Expected this file to have length > 0, was %d", len(contents))
+	}
+}
+
+func TestReadStringOrFileLongString(t *testing.T) {
+	s := "if the string is extremely long it will still try to ask the OS to read this as a file which in some cases will not be allowed because of the length of the file name however the plugin might try this anyways but most file systems only allow a maximum of 255 chars for a file name but up to 4096 for a full path thats a lot of characters"
+	contents, err := readStringOrFile(s)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if contents != s {
+		t.Error("Expected readStringOrFile to return input for a long string")
+	}
+}


### PR DESCRIPTION
If the input string is very long (e.g. over 255 chars on most linux systems), os.IsNotExists() will err with "file name too long". Here's a test case showcasing this and a potential fix.