### PR TITLE
linux-amd64 container image base should be linux-amd64 too

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM plugins/base:multiarch
+FROM plugins/base:linux-amd64
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GitHub Release" \


### PR DESCRIPTION
Hi!

I found some problems while integrating this container image in other CI systems (gitlab-ci).

I want to use it but gitlab-ci requires a shell. As the `linux-amd64` image was using `multiarch`  as base it does not provide any shell.

It worked until today but i think it's a good idea to use the same container tag as the one used as base to build on top of it.

Thanks!