### PR TITLE
More detailed log release info

### DIFF
--- a/plugin/release.go
+++ b/plugin/release.go
@@ -85,6 +85,18 @@ func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {
 		Body:       &rc.Note,
 	}
 
+	if *rr.Prerelease {
+		fmt.Printf("Release %s identified as a pre-release\n", rc.Tag)
+	} else {
+		fmt.Printf("Release %s identified as a full release\n", rc.Tag)
+	}
+
+	if *rr.Draft {
+		fmt.Printf("Release %s will be created as draft (unpublished) release\n", rc.Tag)
+	} else {
+		fmt.Printf("Release %s will be created and published\n", rc.Tag)
+	}
+
 	release, _, err := rc.Client.Repositories.CreateRelease(rc.Context, rc.Owner, rc.Repo, rr)
 
 	if err != nil {


### PR DESCRIPTION
Due that this plugin doesn't show so much information about the release properties chosen.
This PR just logs info about draft and pre-releases as well as full releases according to [GitHub API - Create a release](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#create-a-release).