### PR TITLE
Revert "feature: add option to pick up and publish an existing release draft"

### DIFF
--- a/plugin/release.go
+++ b/plugin/release.go
@@ -39,7 +39,7 @@ func (rc *releaseClient) buildRelease() (*github.RepositoryRelease, error) {
 		release, err = rc.newRelease()
 	} else if release != nil && rc.Overwrite {
 		// update release if exists
-		release, err = rc.editRelease(*release)
+		release, err = rc.editRelease(*release.ID)
 	}
 
 	if err != nil {
@@ -50,61 +50,30 @@ func (rc *releaseClient) buildRelease() (*github.RepositoryRelease, error) {
 }
 
 func (rc *releaseClient) getRelease() (*github.RepositoryRelease, error) {
+	release, _, err := rc.Client.Repositories.GetReleaseByTag(rc.Context, rc.Owner, rc.Repo, rc.Tag)
 
-	listOpts := &github.ListOptions{PerPage: 10}
-
-	for {
-		// get list of releases (10 releases per page)
-		releases, resp, err := rc.Client.Repositories.ListReleases(rc.Context, rc.Owner, rc.Repo, listOpts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list releases: %w", err)
-		}
-
-		// browse through current release page
-		for _, release := range releases {
-
-			// return release associated to the given tag (can only be one)
-			if release.GetTagName() == rc.Tag {
-				fmt.Printf("Found release %d for tag %s\n", release.GetID(), release.GetTagName())
-				return release, nil
-			}
-		}
-
-		// end of list found without finding a matching release
-		if resp.NextPage == 0 {
-			fmt.Println("no existing release (draft) found for the given tag")
-			return nil, nil
-		}
-
-		// go to next page in the next iteration
-		listOpts.Page = resp.NextPage
+	if err != nil {
+		return nil, fmt.Errorf("release %s not found", rc.Tag)
 	}
+
+	fmt.Printf("Successfully retrieved %s release\n", rc.Tag)
+	return release, nil
 }
 
-func (rc *releaseClient) editRelease(targetRelease github.RepositoryRelease) (*github.RepositoryRelease, error) {
-
-	sourceRelease := &github.RepositoryRelease{
+func (rc *releaseClient) editRelease(rid int64) (*github.RepositoryRelease, error) {
+	rr := &github.RepositoryRelease{
 		Name: &rc.Title,
 		Body: &rc.Note,
 	}
 
-	// only potentially change the draft value, if it's a draft right now
-	// i.e. a drafted release will be published, but a release won't be unpublished
-	if targetRelease.GetDraft() {
-		if !rc.Draft {
-			fmt.Println("Publishing a release draft")
-		}
-		sourceRelease.Draft = &rc.Draft
-	}
-
-	modifiedRelease, _, err := rc.Client.Repositories.EditRelease(rc.Context, rc.Owner, rc.Repo, targetRelease.GetID(), sourceRelease)
+	release, _, err := rc.Client.Repositories.EditRelease(rc.Context, rc.Owner, rc.Repo, rid, rr)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to update release: %w", err)
 	}
 
 	fmt.Printf("Successfully updated %s release\n", rc.Tag)
-	return modifiedRelease, nil
+	return release, nil
 }
 
 func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {


### PR DESCRIPTION
Reverts drone-plugins/drone-github-release#68 due to reported panic that occurs

```
Status: Image is up to date for plugins/github-release:latest
no existing release (draft) found for the given tag
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x80f256]

goroutine 1 [running]:
github.com/drone-plugins/drone-github-release/plugin.(*Plugin).Execute(0xc000156b00, 0x0, 0x0)
    /drone/src/plugin/impl.go:147 +0x386
main.run.func1(0xc00012fa40, 0xc000120a00, 0x50)
    /drone/src/cmd/drone-github-release/main.go:60 +0x386
github.com/urfave/cli/v2.(*App).RunContext(0xc00012c180, 0x9fb1a0, 0xc000118000, 0xc0001041c0, 0x1, 0x1, 0x0, 0x0)
    /go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:315 +0x70b
github.com/urfave/cli/v2.(*App).Run(...)
    /go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
main.main()
    /drone/src/cmd/drone-github-release/main.go:37 +0x223
```

I did not have time to research this fully, but it is likely caused by the code path in the `releaseClient` that returns `nil, nil` which results in the the plugin attempting to dereferencing a nil pointer to the release ID.