### PR TITLE
Allow creating/updating the release discussion category

### DIFF
--- a/cmd/drone-github-release/config.go
+++ b/cmd/drone-github-release/config.go
@@ -70,6 +70,12 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			Destination: &settings.Prerelease,
 		},
 		&cli.StringFlag{
+			Name:        "discussion-category",
+			Usage:       "create a discussion in the given category",
+			EnvVars:     []string{"PLUGIN_DISCUSSION_CATEGORY", "GITHUB_RELEASE_DISCUSSION_CATEGORY"},
+			Destination: &settings.DiscussionCategory,
+		},
+		&cli.StringFlag{
 			Name:        "base-url",
 			Usage:       "api url, needs to be changed for ghe",
 			EnvVars:     []string{"PLUGIN_BASE_URL", "GITHUB_RELEASE_BASE_URL"},

--- a/cmd/drone-github-release/main.go
+++ b/cmd/drone-github-release/main.go
@@ -10,11 +10,11 @@ package main
 import (
 	"os"
 
+	"github.com/drone-plugins/drone-github-release/plugin"
 	"github.com/drone-plugins/drone-plugin-lib/errors"
 	"github.com/drone-plugins/drone-plugin-lib/urfave"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli/v2"
-	"github.com/drone-plugins/drone-github-release/plugin"
 )
 
 var version = "unknown"

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -28,6 +28,7 @@ type Settings struct {
 	ChecksumFlatten      bool
 	Draft                bool
 	Prerelease           bool
+	DiscussionCategory   string
 	BaseURL              string
 	UploadURL            string
 	Title                string
@@ -143,6 +144,7 @@ func (p *Plugin) Execute() error {
 		Tag:                  strings.TrimPrefix(p.pipeline.Commit.Ref, "refs/tags/"),
 		Draft:                p.settings.Draft,
 		Prerelease:           p.settings.Prerelease,
+		DiscussionCategory:   p.settings.DiscussionCategory,
 		FileExists:           p.settings.FileExists,
 		Title:                p.settings.Title,
 		Note:                 p.settings.Note,

--- a/plugin/release.go
+++ b/plugin/release.go
@@ -24,6 +24,7 @@ type releaseClient struct {
 	Draft                bool
 	Prerelease           bool
 	FileExists           string
+	DiscussionCategory   string
 	Title                string
 	Note                 string
 	Overwrite            bool
@@ -96,11 +97,17 @@ func (rc *releaseClient) editRelease(targetRelease github.RepositoryRelease) (*g
 	// only potentially change the draft value, if it's a draft right now
 	// i.e. a drafted release will be published, but a release won't be unpublished
 	if targetRelease.GetDraft() {
-		fmt.Printf("DRAFT: %+v\n", rc.Draft)
 		if !rc.Draft {
 			fmt.Println("Publishing a release draft")
 		}
 		sourceRelease.Draft = &rc.Draft
+	}
+
+	// do not overwrite the discussion category
+	if targetRelease.GetDiscussionCategoryName() == "" {
+		if rc.DiscussionCategory != "" {
+			sourceRelease.DiscussionCategoryName = &rc.DiscussionCategory
+		}
 	}
 
 	modifiedRelease, _, err := rc.Client.Repositories.EditRelease(rc.Context, rc.Owner, rc.Repo, targetRelease.GetID(), sourceRelease)
@@ -115,12 +122,13 @@ func (rc *releaseClient) editRelease(targetRelease github.RepositoryRelease) (*g
 
 func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {
 	rr := &github.RepositoryRelease{
-		TagName:              github.String(rc.Tag),
-		Draft:                &rc.Draft,
-		Prerelease:           &rc.Prerelease,
-		Name:                 &rc.Title,
-		Body:                 &rc.Note,
-		GenerateReleaseNotes: &rc.GenerateReleaseNotes,
+		TagName:                github.String(rc.Tag),
+		Draft:                  &rc.Draft,
+		Prerelease:             &rc.Prerelease,
+		DiscussionCategoryName: &rc.DiscussionCategory,
+		Name:                   &rc.Title,
+		Body:                   &rc.Note,
+		GenerateReleaseNotes:   &rc.GenerateReleaseNotes,
 	}
 
 	if *rr.Prerelease {
@@ -137,6 +145,12 @@ func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {
 
 	if *rr.GenerateReleaseNotes {
 		fmt.Printf("Release notes for %s will be automatically generated\n", rc.Tag)
+	}
+
+	if *rr.DiscussionCategoryName != "" {
+		fmt.Printf("Release discussion in category %s\n", *rr.DiscussionCategoryName)
+	} else {
+		fmt.Println("Not creating a discussion")
 	}
 
 	release, _, err := rc.Client.Repositories.CreateRelease(rc.Context, rc.Owner, rc.Repo, rr)


### PR DESCRIPTION
This PR adds release discussions to the plugin.

Commit Message:
- bump GitHub dep to v35.3.0 as this was introduced in v35.1.0
- add new string flag "discussion-category" (+ env vars)
- update release: only set category, if not set
- NOTE: Currently it looks like release drafts with discussion category
set do not "persist" the category when being released, so when
publishing a release draft, without explicitly setting the category, it
won't have a release discussion. Nothing we can do here I suppose.

![create_release](https://user-images.githubusercontent.com/25345277/123259560-e42a0580-d4f4-11eb-9d13-faea36bb786f.png)
![release_with_discussion](https://user-images.githubusercontent.com/25345277/123259562-e55b3280-d4f4-11eb-9f40-31551a4235b4.png)

