### PR TITLE
Allow creating/updating the release discussion category

### DIFF
--- a/cmd/drone-github-release/config.go
+++ b/cmd/drone-github-release/config.go
@@ -64,6 +64,12 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			Destination: &settings.Prerelease,
 		},
 		&cli.StringFlag{
+			Name:        "discussion-category",
+			Usage:       "create a discussion in the given category",
+			EnvVars:     []string{"PLUGIN_DISCUSSION_CATEGORY", "GITHUB_RELEASE_DISCUSSION_CATEGORY"},
+			Destination: &settings.DiscussionCategory,
+		},
+		&cli.StringFlag{
 			Name:        "base-url",
 			Usage:       "api url, needs to be changed for ghe",
 			Value:       "https://api.github.com/",

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/drone-plugins/drone-plugin-lib v0.4.0
-	github.com/google/go-github/v35 v35.0.0
+	github.com/google/go-github/v35 v35.3.0
 	github.com/joho/godotenv v1.3.0
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78
+	golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6
 )

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,11 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v35 v35.0.0 h1:oLrHdYkSQvbhN4gJihpEkTFKAZnIFgTCj1p/OlE4Os4=
 github.com/google/go-github/v35 v35.0.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
+github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
+github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -210,6 +213,8 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 h1:rPRtHfUb0UKZeZ6GH4K4Nt4YRbE9V1u+QZX5upZXqJQ=
 golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6 h1:pERGha6IgvMUdN6oJbwjZTt1ai5/O855Qmv1Bsc0v18=
+golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -19,19 +19,20 @@ import (
 
 // Settings for the plugin.
 type Settings struct {
-	APIKey          string
-	Files           cli.StringSlice
-	FileExists      string
-	Checksum        cli.StringSlice
-	ChecksumFile    string
-	ChecksumFlatten bool
-	Draft           bool
-	Prerelease      bool
-	BaseURL         string
-	UploadURL       string
-	Title           string
-	Note            string
-	Overwrite       bool
+	APIKey             string
+	Files              cli.StringSlice
+	FileExists         string
+	Checksum           cli.StringSlice
+	ChecksumFile       string
+	ChecksumFlatten    bool
+	Draft              bool
+	Prerelease         bool
+	DiscussionCategory string
+	BaseURL            string
+	UploadURL          string
+	Title              string
+	Note               string
+	Overwrite          bool
 
 	baseURL   *url.URL
 	uploadURL *url.URL
@@ -125,17 +126,18 @@ func (p *Plugin) Execute() error {
 	client.UploadURL = p.settings.uploadURL
 
 	rc := releaseClient{
-		Client:     client,
-		Context:    p.network.Context,
-		Owner:      p.pipeline.Repo.Owner,
-		Repo:       p.pipeline.Repo.Name,
-		Tag:        strings.TrimPrefix(p.pipeline.Commit.Ref, "refs/tags/"),
-		Draft:      p.settings.Draft,
-		Prerelease: p.settings.Prerelease,
-		FileExists: p.settings.FileExists,
-		Title:      p.settings.Title,
-		Note:       p.settings.Note,
-		Overwrite:  p.settings.Overwrite,
+		Client:             client,
+		Context:            p.network.Context,
+		Owner:              p.pipeline.Repo.Owner,
+		Repo:               p.pipeline.Repo.Name,
+		Tag:                strings.TrimPrefix(p.pipeline.Commit.Ref, "refs/tags/"),
+		Draft:              p.settings.Draft,
+		Prerelease:         p.settings.Prerelease,
+		DiscussionCategory: p.settings.DiscussionCategory,
+		FileExists:         p.settings.FileExists,
+		Title:              p.settings.Title,
+		Note:               p.settings.Note,
+		Overwrite:          p.settings.Overwrite,
 	}
 
 	release, err := rc.buildRelease()


### PR DESCRIPTION
- bump GitHub dep to v35.3.0 as this was introduced in v35.1.0
- add new string flag "discussion-category" (+ env vars)
- update release: only set category, if not set
- NOTE: Currently it looks like release drafts with discussion category
set do not "persist" the category when being released, so when
publishing a release draft, without explicitly setting the category, it
won't have a release discussion. Nothing we can do here I suppose.

Signed-off-by: Thorsten Klein <iwilltry42@gmail.com>

source: https://github.com/drone-plugins/drone-github-release/pull/89
