### PR TITLE
Fix not overwriting all existing assets

### DIFF
--- a/plugin/release.go
+++ b/plugin/release.go
@@ -151,7 +151,7 @@ func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {
 
 func (rc *releaseClient) uploadFiles(id int64, files []string) error {
 	var assets []*github.ReleaseAsset
-	listOpts := &github.ListOptions{}
+	var listOpts *github.ListOptions
 	for {
 		a, resp, err := rc.Client.Repositories.ListReleaseAssets(rc.Context, rc.Owner, rc.Repo, id, listOpts)
 		if err != nil {
@@ -165,6 +165,9 @@ func (rc *releaseClient) uploadFiles(id int64, files []string) error {
 		}
 
 		// go to next page in the next iteration
+		if listOpts == nil {
+			listOpts = &github.ListOptions{}
+		}
 		listOpts.Page = resp.NextPage
 	}
 

--- a/plugin/release.go
+++ b/plugin/release.go
@@ -151,7 +151,7 @@ func (rc *releaseClient) newRelease() (*github.RepositoryRelease, error) {
 
 func (rc *releaseClient) uploadFiles(id int64, files []string) error {
 	var assets []*github.ReleaseAsset
-	var listOpts *github.ListOptions
+	listOpts := &github.ListOptions{PerPage: 10}
 	for {
 		a, resp, err := rc.Client.Repositories.ListReleaseAssets(rc.Context, rc.Owner, rc.Repo, id, listOpts)
 		if err != nil {
@@ -164,10 +164,6 @@ func (rc *releaseClient) uploadFiles(id int64, files []string) error {
 			break
 		}
 
-		// go to next page in the next iteration
-		if listOpts == nil {
-			listOpts = &github.ListOptions{}
-		}
 		listOpts.Page = resp.NextPage
 	}
 


### PR DESCRIPTION
This PR fixes an issue where overwriting some assets in releases with more than 30 assets can fail with a 422 error from GitHub (possibly related to #88). 