### PR TITLE
Determine API endpoints from GitHub server

### DIFF
--- a/cmd/drone-github-release/config.go
+++ b/cmd/drone-github-release/config.go
@@ -14,6 +14,12 @@ import (
 func settingsFlags(settings *plugin.Settings) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "github-url",
+			Usage:       "github url, defaults to current scm",
+			EnvVars:     []string{"PLUGIN_GITHUB_URL", "DRONE_REPO_LINK"},
+			Destination: &settings.GitHubURL,
+		},
+		&cli.StringFlag{
 			Name:        "api-key",
 			Usage:       "api key to access github api",
 			EnvVars:     []string{"PLUGIN_API_KEY", "GITHUB_RELEASE_API_KEY", "GITHUB_TOKEN"},
@@ -66,14 +72,12 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "base-url",
 			Usage:       "api url, needs to be changed for ghe",
-			Value:       "https://api.github.com/",
 			EnvVars:     []string{"PLUGIN_BASE_URL", "GITHUB_RELEASE_BASE_URL"},
 			Destination: &settings.BaseURL,
 		},
 		&cli.StringFlag{
 			Name:        "upload-url",
 			Usage:       "upload url, needs to be changed for ghe",
-			Value:       "https://uploads.github.com/",
 			EnvVars:     []string{"PLUGIN_UPLOAD_URL", "GITHUB_RELEASE_UPLOAD_URL"},
 			Destination: &settings.UploadURL,
 		},

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -16,3 +16,27 @@ func TestValidate(t *testing.T) {
 func TestExecute(t *testing.T) {
 	t.Skip()
 }
+
+func TestGitHubURLs(t *testing.T) {
+	// GitHub case
+	actualBaseURL, actualUploadURL, _ := gitHubURLs("https://github.com/drone-plugins/drone-release-download")
+	expectedBaseURL := "https://api.github.com/"
+	if actualBaseURL.String() != expectedBaseURL {
+		t.Errorf("Unexpected base API URL (Got: %s, Expected: %s", actualBaseURL.String(), expectedBaseURL)
+	}
+	expectedUploadURL := "https://uploads.github.com/"
+	if actualUploadURL.String() != expectedUploadURL {
+		t.Errorf("Unexpected upload API URL (Got: %s, Expected: %s", actualUploadURL.String(), expectedUploadURL)
+	}
+
+	// GitHub Enterprise case
+	actualBaseURL, actualUploadURL, _ = gitHubURLs("https://github.enterprise.drone.io/drone-plugins/drone-release-download")
+	expectedBaseURL = "https://github.enterprise.drone.io/api/v3/"
+	if actualBaseURL.String() != expectedBaseURL {
+		t.Errorf("Unexpected base API URL (Got: %s, Expected: %s", actualBaseURL.String(), expectedBaseURL)
+	}
+	expectedUploadURL = "https://github.enterprise.drone.io/api/v3/upload/"
+	if actualUploadURL.String() != expectedUploadURL {
+		t.Errorf("Unexpected upload API URL (Got: %s, Expected: %s", actualUploadURL.String(), expectedUploadURL)
+	}
+}


### PR DESCRIPTION
Both GitHub and GitHub Enterprise have a well defined path for both the base and upload endpoints. The `DRONE_REPO_LINK` gives the server address so just use that to compute the endpoints rather than relying on the user to enter them manually.

