### PR TITLE
feat: add generate-release-notes parameter

### DIFF
--- a/cmd/drone-github-release/config.go
+++ b/cmd/drone-github-release/config.go
@@ -99,5 +99,11 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			EnvVars:     []string{"PLUGIN_OVERWRITE", "GITHUB_RELEASE_OVERWRIDE"},
 			Destination: &settings.Overwrite,
 		},
+		&cli.BoolFlag{
+			Name:        "generate-release-notes",
+			Usage:       "whether to automatically generate the name and body for this release",
+			EnvVars:     []string{"PLUGIN_GENERATE_RELEASE_NOTES", "GITHUB_GENERATE_RELEASE_NOTES"},
+			Destination: &settings.GenerateReleaseNotes,
+		},
 	}
 }


### PR DESCRIPTION
Add a parameter that sets the "generate_release_notes" boolean option of the API call. When set, it autogenerates a release note.

The parameter defaults to "false" so this is not a breaking change. See documentation on https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release